### PR TITLE
fix : add space between -D and TARGET_SOC

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ cd ../
 
 # build
 # TARGET_SOC = RK3588 or RK356X or RV110X
-colcon build --symlink-install --packages-up-to rknpu2_ros --cmake-args -DTARGET_SOC=RK3588
+colcon build --symlink-install --packages-up-to rknpu2_ros --cmake-args -D TARGET_SOC=RK3588
 ```
 
 ## run


### PR DESCRIPTION
Thanks for making such a nice package.

Unfortunately, the error below occurred during build, and to solve it, I add space between -D and TARGET_SOC :)
``` bash
orangepi@orangepi5:~$ colcon build --symlink-install --packages-up-to rknpu2_ros --cmake-args -DTARGET_SOC=RK3588
Starting >>> bboxes_ex_msgs
Starting >>> rknpu2_ros_common
--- stderr: rknpu2_ros_common                                                                     
CMake Warning:
  Manually-specified variables were not used by the project:

    TARGET_SOC


---
Finished <<< rknpu2_ros_common [3.16s]
--- stderr: bboxes_ex_msgs                              
CMake Warning:
  Manually-specified variables were not used by the project:

    TARGET_SOC


---
Finished <<< bboxes_ex_msgs [12.0s]
Starting >>> rknpu2_ros_yolov5
Aborted  <<< rknpu2_ros_yolov5 [1.14s]                   

Summary: 2 packages finished [13.8s]
  1 package aborted: rknpu2_ros_yolov5
  3 packages had stderr output: bboxes_ex_msgs rknpu2_ros_common rknpu2_ros_yolov5
  1 package not processed

```